### PR TITLE
[Fix] 타입스크립트에서 meta 이하의 env가 무엇인지 몰라 발생하는 에러 해결

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,5 +6,5 @@ import "./index.css";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,5 +6,5 @@ import "./index.css";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+interface ImportMeta {
+  env: {
+    DEV: string;
+  };
+}


### PR DESCRIPTION
# 설명
- 타입스크립트에서 meta 이하의 env가 무엇인지 몰라 발생하는 에러를 해결하기 위해 `env.d.ts `파일을 추가하여 인터페이스를 통한 타입 추론을 하여 문제를 해결하였습니다.
## 무슨 종류의 PR인지?

- [ ] 🕹️ Feat
- [X] 📌 Fix
- [ ] 🔖 Documentation Update
- [ ] 🎨 Style
- [ ] 🔎 Code Refactor
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

# 어떻게 테스트 되었는가?

- [ ] 테스트 코드 작성
- [ ] 로컬환경에서 수동 테스트 진행

# 티켓 번호
[JAE_63](https://linear.app/jaehyeok/issue/JAE-63/%5B1%5D-%ED%83%80%EC%9E%85%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8%EC%97%90%EC%84%9C-meta-%EC%9D%B4%ED%95%98%EC%9D%98-env%EA%B0%80-%EB%AC%B4%EC%97%87%EC%9D%B8%EC%A7%80-%EB%AA%B0%EB%9D%BC-%EB%B0%9C%EC%83%9D%ED%95%98%EB%8A%94-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0)
